### PR TITLE
RDKBCMF-291 rdk-easymesh-controller 64bit build failures

### DIFF
--- a/source/controller/src/Makefile.am
+++ b/source/controller/src/Makefile.am
@@ -39,9 +39,16 @@ em_ctl_SOURCES = $(srcdir)/map_ctrl_cli.c \
 em_ctl_LDADD = ${top_builddir}/source/libplatform/src/libutils.a \
                ${top_builddir}/source/ieee1905/src/al/libal.a \
                ${top_builddir}/source/ieee1905/src/factory/libfactory.a \
-               ${top_builddir}/source/ieee1905/src/common/libcommon.a \               
-               ${top_builddir}/source/ssp/libssp.a
-
+               ${top_builddir}/source/ieee1905/src/common/libcommon.a \
+               ${top_builddir}/source/ssp/libssp.a \
+               -ldbus-1 \
+               -lrdkloggers \
+               -ljson-c \
+               -lz \
+               -lcrypto \
+               -lpthread \
+               -lccsp_common \
+               -lubox
 
 em_ctl_CPPFLAGS += $(SYSTEMD_CFLAGS) 
 em_ctl_CPPFLAGS += "-DFEATURE_SUPPORT_RDKLOG"


### PR DESCRIPTION
Build errors in RPi 64bit builds in the rdk-easymesh-controller component:
-Wimplicit-function-declaration
-Wint-conversion
undefined references