### PR TITLE
RDKBDEV-1210 : Logging Improvements and Fixes

### DIFF
--- a/source/libplatform/include/map_config.h
+++ b/source/libplatform/include/map_config.h
@@ -61,7 +61,8 @@ typedef struct {
 
 typedef enum {
     log_syslog,
-    log_stderr
+    log_stderr,
+    log_file_only
 } map_log_iface_t;
 
 /* Credential type. See Device.X_AIRTIES_OBJ.MultiapController.SSIDProfile.{i}.Type.
@@ -137,9 +138,6 @@ typedef struct map_cfg_s {
     unsigned int          library_log_level;
     unsigned int          ieee1905_log_level;
     unsigned int          controller_log_level;
-    unsigned int          agent_log_level;
-    unsigned int          vendor_ipc_log_level;
-    unsigned int          controller_bhs_log_level;
     int                   al_fd;
 
     char                 *manufacturer;

--- a/source/libplatform/include/map_utils.h
+++ b/source/libplatform/include/map_utils.h
@@ -147,10 +147,7 @@ uint64_t get_clock_diff_secs(struct timespec new_time, struct timespec old_time)
 typedef enum {
     MAP_LIBRARY,
     MAP_IEEE1905,
-    MAP_AGENT,
     MAP_CONTROLLER,
-    MAP_VENDOR_IPC,
-    MAP_CONTROLLER_BHS,
     MAP_TEST
 } map_log_source_t;
 


### PR DESCRIPTION
Reason for change: Log mechanism was not working properly. rdklogger support was implemented buggy. Wrong usage of variable arguments in logging functions is fixed. No modification of internal log levels was possible besides build time. Environment variables are added to modify internal log levels and log output.
Test Procedure: Modify RdkEasyMeshController.service for environment variables. Available environment variables and values are
    MAP_CONTROLLER_LOG_LEVEL (error, warn, info, debug)
    MAP_PLATFORM_LOG_LEVEL (error, warn, info, debug)
    MAP_IEEE1905_LOG_LEVEL (error, warn, info, debug)
    MAP_LOG_OUTPUT (stderr, syslog, file_only)
Run systemctl daemon-reload; systemctl restart RdkEasyMeshController for the changes to take effect
Risks: Low

Signed-off-by: Engin Akca <engin.akca@airties.com>