### PR TITLE
REFPLTB-2710: rdk-easy-mesh controller compilation issue in kirkstone

### DIFF
--- a/source/libplatform/src/acu_utils.c
+++ b/source/libplatform/src/acu_utils.c
@@ -83,7 +83,7 @@ static acu_retcode_t mac_from_string(const char *s, uint8_t *m, size_t l)
 }
 
 /* Convert uint8_t array to aa:bb:... */
-static acu_retcode_t mac_to_string(const uint8_t *m, mac_addr_str s, size_t l)
+static acu_retcode_t mac_to_string(const uint8_t *m, char *s, size_t l)
 {
     static char hex[]={'0','1','2','3','4','5','6','7','8','9','a','b','c','d','e','f'};
     size_t i, p = 0;


### PR DESCRIPTION
Reason for change: In Kirkstone build, faced below issue after removing the stringop-overflow flag
./../../../../../../../../../rdkb/components/opensource/ccsp/RdkEasyMeshController/source/libplatform/src/acu_utils.c:121:12: error: 'mac_to_string' accessing 18 bytes in a region of size 9 [-Werror=stringop-overflow=]|   121 |     return mac_to_string(oui, ouistr, sizeof(mac_addr_oui));|       |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~| ../../../../../../../../../../rdkb/components/opensource/ccsp/RdkEasyMeshController/source/libplatform/src/acu_utils.c:121:12: note: referencing argument 2 of type 'char *'| ../../../../../../../../../../rdkb/components/opensource/ccsp/RdkEasyMeshController/source/libplatform/src/acu_utils.c:86:22: note: in a call to function 'mac_to_string'|    86 | static acu_retcode_t mac_to_string(const uint8_t *m, mac_addr_str s, size_t l)|
To resolve that , increased the buffer size
Test Procedure: 1. Verified that it is not affecting dunfell build.
                2. Run the component and stringop-overflow should not observed

Risks: None