### PR TITLE
REFPLTB-2710: Compilation issue in kirkstone

### DIFF
--- a/source/libplatform/src/map_dm_rbus.c
+++ b/source/libplatform/src/map_dm_rbus.c
@@ -290,7 +290,6 @@
 #define DM_PROCSTATUS_OBJ       DM_DEVINFO_OBJ      "ProcessStatus."
 #define DM_PROCSTATUS_CPUUSAGE  DM_PROCSTATUS_OBJ   "CPUUsage"
 #define DM_PROCSTATUS_CPUTEMP   DM_PROCSTATUS_OBJ   "CPUTemperature"
-#define DM_PROCSTATUS_CPUTEMP   DM_PROCSTATUS_OBJ   "CPUTemperature"
 /* Device.WiFi.DataElements.AssociationEvent */
 #define DM_ASSOCEVT_OBJ         DM_DATAELEMS_OBJ    "AssociationEvent."
 #define DM_ASSOCEVT_DATANOE     DM_ASSOCEVT_OBJ     "AssociationEventDataNumberOfEntries"


### PR DESCRIPTION
Reason for change: Some functions became obsolete in OpenSSL v3, especially the ones used during key exchange. Alternatives using v3 are added. Successful interaction with old library is preserved.

Test Procedure: bitbake rdk-easymesh-controller

Risks: Low
Change-Id: I7de0056a9949cd1788f561278ad0d8b50f16e634